### PR TITLE
top&header(ログイン前)画面に新規登録へのルーティング実装 （加藤）

### DIFF
--- a/resources/views/commons/before_header.blade.php
+++ b/resources/views/commons/before_header.blade.php
@@ -7,7 +7,7 @@
             <ul>
                 <li>
                     <a class="text-dark" href="{{ url('/login') }}"> ログイン </a>
-                    <a class="text-dark" href="{{ url('/register') }}"> 新規登録 </a>
+                    <a class="text-dark">{!! link_to_route('signup', '新規登録', [], []) !!}</a>
                 </li>
             </ul>
         </div>

--- a/resources/views/front/before_login.blade.php
+++ b/resources/views/front/before_login.blade.php
@@ -6,20 +6,20 @@
         <main>
             <h1 class="mt-5 text-center">やんばるエキスパート ECサイト</h1>
             <div class="row d-flex justify-content-center align-items-center">
-              <div class="mt-3 mx-3 text-center">
-              <p>
-                まだアカウントを<br>
-                お持ちでない方はこちら
-              </p>
-              <a role="button">{!! link_to_route('signup', '新規登録', [], ['class' => 'btn btn-primary']) !!}</a>
-            </div>
-              <div class="mt-3 mx-3 text-center">
-              <p>
-                すでにアカウントを<br>
-                お持ちの方はこちら
-              </p>
-              <a class="btn btn-primary" href="{{ url('/login') }}" role="button">ログイン</a>
-              </div>
+                <div class="mt-3 mx-3 text-center">
+                    <p>
+                        まだアカウントを<br>
+                        お持ちでない方はこちら
+                    </p>
+                    <a role="button">{!! link_to_route('signup', '新規登録', [], ['class' => 'btn btn-primary']) !!}</a>
+                </div>
+                <div class="mt-3 mx-3 text-center">
+                    <p>
+                        すでにアカウントを<br>
+                        お持ちの方はこちら
+                    </p>
+                    <a class="btn btn-primary" href="{{ url('/login') }}" role="button">ログイン</a>
+                </div>
             </div>
         </main>
     </body>

--- a/resources/views/front/before_login.blade.php
+++ b/resources/views/front/before_login.blade.php
@@ -11,7 +11,7 @@
                 まだアカウントを<br>
                 お持ちでない方はこちら
               </p>
-              <a class="btn btn-primary" href="{{ url('/register') }}" role="button">新規登録</a>
+              <a role="button">{!! link_to_route('signup', '新規登録', [], ['class' => 'btn btn-primary']) !!}</a>
             </div>
               <div class="mt-3 mx-3 text-center">
               <p>


### PR DESCRIPTION
お疲れさまです！

新規登録画面へのルーティングの記述をしました。
下記2箇所です。画面遷移と遷移先での新規登録機能の確認済みです。
宜しくお願い致します。

・header(ログイン前)
・top画面(ログイン前)