### PR TITLE
検索->詳細 商品が存在しない場合の遷移実装（けーすけ）

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -116,7 +116,6 @@ class CartController extends Controller
             'productCategory' => $productCategory,
             'userId' => $userId,
         ]);
-        
     }
 
     /**

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -103,16 +103,20 @@ class CartController extends Controller
         $userId = '';
 
         //urlパラメータから飛んできたユーザidを元にモデルからそれぞれ商品、カテゴリーを特定
-        $productInfo = MProduct::findOrFail($id);
-        $productCategory = MCategory::findOrFail($productInfo -> category_id);
+        $productInfo = MProduct::find($id);
+        if(!isset($productInfo)){
+            return view('item_notfound'); 
+        }
+        $productCategory = MCategory::find($productInfo -> category_id);
         $userId = Auth::user()->id;
-        
+
         return view('iteminfo', 
         [
             'productInfo' => $productInfo,
             'productCategory' => $productCategory,
             'userId' => $userId,
         ]);
+        
     }
 
     /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -68,4 +68,22 @@ class ProductController extends Controller
     {
         return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $str);
     }
+
+    /*==================================
+    商品詳細の表示メソッド(detail)
+    ==================================*/
+    public function detail(Request $request)
+    {
+        $productId = $request->productId;
+        //unset($productId);
+
+        if (isset($productId)){
+            return redirect(route('iteminfo', [
+                'id' => $productId,
+            ]));
+        }
+        elseif(!isset($productId)){
+            return view('item_notfound'); 
+        }
+    }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -68,5 +68,4 @@ class ProductController extends Controller
     {
         return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $str);
     }
-
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -69,21 +69,4 @@ class ProductController extends Controller
         return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $str);
     }
 
-    /*==================================
-    商品詳細の表示メソッド(detail)
-    ==================================*/
-    public function detail(Request $request)
-    {
-        $productId = $request->productId;
-        //unset($productId);
-
-        if (isset($productId)){
-            return redirect(route('iteminfo', [
-                'id' => $productId,
-            ]));
-        }
-        elseif(!isset($productId)){
-            return view('item_notfound'); 
-        }
-    }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -30,7 +30,7 @@
                 </div>
 
                 <div class="text-center mt-3">
-                    <button type="button" class="btn btn-link">まだ登録がお済みでない方はこちら</button>
+                    {!! link_to_route('signup', 'まだ登録がお済みでない方はこちら', [], ['class' => 'btn btn-link']) !!}
                 </div>
             </form>
         {!! Form::close() !!}

--- a/resources/views/item_notfound.blade.php
+++ b/resources/views/item_notfound.blade.php
@@ -7,7 +7,7 @@
                 <h3 class="pt-5">商品検索画面に戻り、やり直してください</h3>
                 
                 <h3 class="pt-5">
-                {!! link_to_route('show', '商品検索画面', [], ['class' => 'btn btn-primary btn-lg']) !!}
+                    {!! link_to_route('show', '商品検索画面', [], ['class' => 'btn btn-primary btn-lg']) !!}
                 </h3>
             </div>
         </div>

--- a/resources/views/item_notfound.blade.php
+++ b/resources/views/item_notfound.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+@section('content')
+    <main>
+        <div class="container">
+            <div class="mx-auto">
+                <h2 class="pt-5">該当商品が見つかりませんでした...</h2>
+                <h3 class="pt-5">商品検索画面に戻り、やり直してください</h3>
+                
+                <h3 class="pt-5">
+                {!! link_to_route('show', '商品検索画面', [], ['class' => 'btn btn-primary btn-lg']) !!}
+                </h3>
+            </div>
+        </div>
+    </main>
+@endsection

--- a/resources/views/searchproduct.blade.php
+++ b/resources/views/searchproduct.blade.php
@@ -60,14 +60,9 @@
           <td>{{ $product->product_name }}</td>
           <td>{{ $product->category->category_name }}</td>
           <td>{{ $product->price }}円</td>
-
-          {!! Form::open(['route' => 'detail']) !!}
-            {{ Form::hidden('productId', $product->id) }}
-            <td>
-              {!! Form::submit('商品詳細', ['class' => 'btn btn-primary btn-sm']) !!}
-            </td>
-          {!! Form::close() !!}
-
+          <td>
+          {!! link_to_route('iteminfo', '商品詳細', ['id' => $product->id ], ['class' => 'btn btn-primary btn-sm']) !!}
+          </td>
         </tr>
         @endforeach   
       </table>

--- a/resources/views/searchproduct.blade.php
+++ b/resources/views/searchproduct.blade.php
@@ -61,7 +61,7 @@
           <td>{{ $product->category->category_name }}</td>
           <td>{{ $product->price }}円</td>
           <td>
-          {!! link_to_route('iteminfo', '商品詳細', ['id' => $product->id ], ['class' => 'btn btn-primary btn-sm']) !!}
+              {!! link_to_route('iteminfo', '商品詳細', ['id' => $product->id ], ['class' => 'btn btn-primary btn-sm']) !!}
           </td>
         </tr>
         @endforeach   

--- a/resources/views/searchproduct.blade.php
+++ b/resources/views/searchproduct.blade.php
@@ -60,7 +60,14 @@
           <td>{{ $product->product_name }}</td>
           <td>{{ $product->category->category_name }}</td>
           <td>{{ $product->price }}円</td>
-          <td><a href="#" class="btn btn-primary btn-sm">商品詳細</a></td>
+
+          {!! Form::open(['route' => 'detail']) !!}
+            {{ Form::hidden('productId', $product->id) }}
+            <td>
+              {!! Form::submit('商品詳細', ['class' => 'btn btn-primary btn-sm']) !!}
+            </td>
+          {!! Form::close() !!}
+
         </tr>
         @endforeach   
       </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,15 +84,11 @@ Route::put('/user_update', 'UserController@update')->name('user_update');
 Route::get('/delete', 'UserController@delete')->name('user_delete');
 Route::post('/remove', 'UserController@remove')->name('user_remove');
 
-<<<<<<< HEAD
-   
-=======
 
 
 //商品検索機能
 Route::get('show', 'ProductController@index')->name('show');
 
->>>>>>> develop_alpha
 /*
 |--------------------------------------------------------------------------
 | 商品検索機能

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,7 +85,7 @@ Route::post('/remove', 'UserController@remove')->name('user_remove');
 */
 Route::get('show', 'ProductController@index')->name('show');
 Route::get('searchproduct', 'ProductController@search')->name('searchproduct');
-Route::post('detail', 'ProductController@detail')->name('detail');
+// Route::post('detail', 'ProductController@detail')->name('detail');
 
 
 /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,7 +85,7 @@ Route::post('/remove', 'UserController@remove')->name('user_remove');
 */
 Route::get('show', 'ProductController@index')->name('show');
 Route::get('searchproduct', 'ProductController@search')->name('searchproduct');
-// Route::post('detail', 'ProductController@detail')->name('detail');
+
 
 
 /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,22 +78,26 @@ Route::get('/delete', 'UserController@delete')->name('user_delete');
 Route::post('/remove', 'UserController@remove')->name('user_remove');
 
    
-
-//商品検索機能
+/*
+|--------------------------------------------------------------------------
+| 商品検索機能
+|--------------------------------------------------------------------------
+*/
 Route::get('show', 'ProductController@index')->name('show');
+Route::get('searchproduct', 'ProductController@search')->name('searchproduct');
+Route::post('detail', 'ProductController@detail')->name('detail');
+
 
 /*
 |--------------------------------------------------------------------------
-| 開発中
+| カート機能
 |--------------------------------------------------------------------------
 */
-
-
 Route::resource('cartitem', 'CartController', ['only' => ['index']]);
 
 Route::group(["prefix" => 'iteminfo'], function() {
-    Route::get('/{id}', 'CartController@show');
+    Route::get('/{id}', 'CartController@show')->name('iteminfo');
     Route::post('/add', 'CartController@addCart')->name('addcart');
 });
 
-Route::get('searchproduct', 'ProductController@search')->name('searchproduct');
+


### PR DESCRIPTION
検索画面から詳細画面に遷移する際に、商品が存在しなかった場合の実装が抜けており、実装いたしました。
また、ルーティングファイルが少し乱れておりましたので、整理しております。
ご確認をお願いいたします。

追記
全てルーティングをiteminfoにまとめまてみました！動作チェック済みです。
また、「まだ登録がお済みでないかたはこちら」のリンクも作成しておきました。
お手数ですが、再度ご確認をお願いいたします。