### PR TITLE
追加：商品検索画面から商品詳細画面への遷移（まこと）

### DIFF
--- a/resources/views/shopping/product_search.blade.php
+++ b/resources/views/shopping/product_search.blade.php
@@ -53,7 +53,6 @@
                     <td>{{ $product->category->category_name }}</td>
                     <td>{{ $product->price }}円</td>
                     <td><a href="{{ route('prodinfo', ['id' => $product->id])}}" class="btn btn-primary btn-sm">商品詳細</a></td>
-                    <!-- <td><a href="#" class="btn btn-primary btn-sm">商品詳細</a></td> -->
                 </tr>
                 @endforeach
             </table>

--- a/resources/views/shopping/product_search.blade.php
+++ b/resources/views/shopping/product_search.blade.php
@@ -52,7 +52,8 @@
                     <td>{{ $product->product_name }}</td>
                     <td>{{ $product->category->category_name }}</td>
                     <td>{{ $product->price }}円</td>
-                    <td><a href="#" class="btn btn-primary btn-sm">商品詳細</a></td>
+                    <td><a href="{{ route('prodinfo', ['id' => $product->id])}}" class="btn btn-primary btn-sm">商品詳細</a></td>
+                    <!-- <td><a href="#" class="btn btn-primary btn-sm">商品詳細</a></td> -->
                 </tr>
                 @endforeach
             </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,7 @@ Route::get('/no-product', function () {
     return view('products/no_product');
 })->name('noProduct');
 Route::get('productInfo/{id}', 'ProductController@show')->name('product.show');
+Route::get('/prodinfo/{id}', 'ProductController@show')->name('prodinfo');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
お疲れ様です！

商品検索画面（/product）における、商品詳細画面（/prodinfo/{id}）への画面遷移を追加しました。

ご確認のほどお願いいたします。